### PR TITLE
Fix talisman compat

### DIFF
--- a/index.lua
+++ b/index.lua
@@ -50,7 +50,7 @@ HeyListen = {
 				if not hey_i_hear_voucher or hey_i_hear_voucher == card then
 					return false
 				end
-				if card.cost == 0 or G.GAME.dollars < (hey_i_hear_voucher.cost + card.cost) then
+				if to_big(card.cost) == to_big(0) or to_big(G.GAME.dollars) < to_big((hey_i_hear_voucher.cost + card.cost)) then
 					return false
 				end
 
@@ -362,4 +362,8 @@ function HeyListen.on_hand_play(button)
 			button.disable_button = false
 		end,
 	})
+end
+
+to_big = to_big or function(x, y)
+    return x
 end


### PR DESCRIPTION
Game crashes when you click a card with the voucher in the shop, if you have the talisman mod installed.

I believe this is because `G.GAME.dollars` becomes a big number table, and so we end up comparing it with a regular number here.

Very simple fix, tested and works for me with and without talisman.